### PR TITLE
Add local multi-app setup with OpenAI review

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your-openai-key
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# gpttest
+# Two App React Dev Environment
+
+This repo contains a small example of running two React apps in a single page.
+App 1 lets you send prompts to OpenAI and App 2 displays the result. The server
+uses your OpenAI API key from the environment.
+
+## Prerequisites
+
+- Node.js (v18 or newer)
+- npm
+
+## Setup
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Copy `.env.example` to `.env` and fill in your OpenAI credentials:
+
+   ```bash
+   cp .env.example .env
+   # edit .env to add OPENAI_API_KEY
+   ```
+
+3. Start the server:
+
+   ```bash
+   npm start
+   ```
+
+4. Open `http://localhost:3000` in your browser. You will see App 1 on the left
+   and App 2 on the right.
+
+The client side uses React via CDN and requires no build step. The server
+handles `/api/review` and forwards requests to OpenAI.

--- a/client/app1.jsx
+++ b/client/app1.jsx
@@ -1,0 +1,37 @@
+function App1() {
+  const [prompt, setPrompt] = React.useState('');
+  const [loading, setLoading] = React.useState(false);
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await fetch('/api/review', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt })
+      });
+      const data = await res.json();
+      window.dispatchEvent(new CustomEvent('openai-result', { detail: data.result || 'No result' }));
+    } catch (err) {
+      console.error(err);
+      window.dispatchEvent(new CustomEvent('openai-result', { detail: 'Request failed' }));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div>
+      <h2>App 1: OpenAI Reviewer</h2>
+      <form onSubmit={handleSubmit}>
+        <textarea rows="5" style={{ width: '100%' }} value={prompt} onChange={e => setPrompt(e.target.value)} />
+        <button type="submit" disabled={loading}>
+          {loading ? 'Sending...' : 'Send'}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+ReactDOM.render(<App1 />, document.getElementById('app1'));

--- a/client/app2.jsx
+++ b/client/app2.jsx
@@ -1,0 +1,20 @@
+function App2() {
+  const [content, setContent] = React.useState('');
+
+  React.useEffect(() => {
+    function handler(e) {
+      setContent(e.detail);
+    }
+    window.addEventListener('openai-result', handler);
+    return () => window.removeEventListener('openai-result', handler);
+  }, []);
+
+  return (
+    <div>
+      <h2>App 2: Result Viewer</h2>
+      <pre style={{ whiteSpace: 'pre-wrap' }}>{content}</pre>
+    </div>
+  );
+}
+
+ReactDOM.render(<App2 />, document.getElementById('app2'));

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Local OpenAI Dev Environment</title>
+    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <style>
+      body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+      #root { display: flex; }
+      #app1, #app2 { flex: 1; padding: 1rem; border: 1px solid #ddd; height: 100vh; overflow: auto; }
+    </style>
+  </head>
+  <body>
+    <div id="root">
+      <div id="app1"></div>
+      <div id="app2"></div>
+    </div>
+    <script type="text/babel" src="app1.jsx"></script>
+    <script type="text/babel" src="app2.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "local-review-dev",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "openai": "^4.0.0",
+    "dotenv": "^16.3.1"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,29 @@
+require('dotenv').config();
+const express = require('express');
+const path = require('path');
+const { Configuration, OpenAIApi } = require('openai');
+
+const app = express();
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'client')));
+
+const openai = new OpenAIApi(
+  new Configuration({ apiKey: process.env.OPENAI_API_KEY })
+);
+
+app.post('/api/review', async (req, res) => {
+  try {
+    const { prompt } = req.body;
+    const completion = await openai.createChatCompletion({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }]
+    });
+    res.json({ result: completion.data.choices[0].message.content });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'OpenAI request failed' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- initialize simple server using Express and OpenAI
- create two small React apps: one to send prompts, one to show results
- document setup steps in README
- provide example environment file

## Testing
- `node server.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_683a50cd4c84832195bed189f5f4120a